### PR TITLE
Fix Makefile VERSION and image build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 
 DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-VERSION=$(shell git describe --tags --match=v* --always --abbrev=0 --dirty)
+VERSION=$(shell git describe --tags --match=v* --always --dirty)
 
 REPO=github.com/poseidon/fleetlock
 LOCAL_REPO=poseidon/fleetlock


### PR DESCRIPTION
* Build container image with the usual git describe version which is a tag (for releases) or a last tag, revision count, and SHA (in between releases)