### PR TITLE
Change successful "unlock" reply

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -213,7 +213,7 @@ func (s *Server) unlock(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// either unlocked or didn't hold
-	fmt.Fprintf(w, "unlocked reboot lease for %s", lock.Holder)
+	fmt.Fprint(w, "steady-state confirmed")
 }
 
 // healthHandler handles liveness checks with an ok status response.


### PR DESCRIPTION
Currently, the reply for successful "/v1/steady-state" requests is misleading:

> unlocked reboot lease for <OWNER_ID>

This response is sent even

- when the machine ID is NOT the holder of the lease (which means that the lease is NOT unlocked),
- or when there's no reboot lease (in which case the reply is `unlocked reboot lease for `)

This commit changes the reply to use a generic message "steady-state confirmed" (which is what Airlock logs in that case).

It is also possible to use three different messages, e.g:

- if the reboot lease was actually unlocked (request.ID = ownerID):

  > unlocked reboot lease for <OWNER_ID>

- if the reboot lease is held by another node:

  > steady-state confirmed for <REQUEST_ID>, reboot lease held by <OWNER_ID>

- if there's no locked lease:

  > steady-state confirmed for <REQUEST_ID>

