### PR TITLE
Add missing return in lock handler request decoding

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -105,6 +105,7 @@ func (s *Server) lock(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		s.log.Errorf("fleetlock: error decoding message: %v", err)
 		encodeReply(w, NewReply(KindDecodeError, "error decoding message"))
+		return
 	}
 	id := msg.ClientParmas.ID
 	group := msg.ClientParmas.Group


### PR DESCRIPTION
* If a request message can't be decoded, a Reply indicating and error should be returned without continuing