### PR TITLE
Update Go version used and alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM docker.io/golang:1.15.3 AS builder
+FROM docker.io/golang:1.15.8 AS builder
 COPY . src
 RUN cd src && make build
 
-FROM docker.io/alpine:3.12
+FROM docker.io/alpine:3.13
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 RUN apk --no-cache --update add ca-certificates
 COPY --from=builder /go/src/bin/fleetlock /usr/local/bin


### PR DESCRIPTION
* Update Go version used from v1.15.3 to v1.15.8
* Update alpine base image
* https://alpinelinux.org/posts/Alpine-3.13.0-released.html