### PR TITLE
ZincatiID method expects MachineID

### DIFF
--- a/internal/drain.go
+++ b/internal/drain.go
@@ -58,7 +58,7 @@ func (s *Server) matchNode(ctx context.Context, id string) (*v1.Node, error) {
 	}
 
 	for _, node := range nodes.Items {
-		zincatiID, err := ZincatiID(node.Status.NodeInfo.SystemUUID)
+		zincatiID, err := ZincatiID(node.Status.NodeInfo.MachineID)
 		if err == nil && id == zincatiID {
 			fields["node"] = node.GetName()
 			s.log.WithFields(fields).Info("fleetlock: Zincati request matches Kubernetes node")


### PR DESCRIPTION
ZincatiID uses machineID to match.

I tested this locally and the SystemUUID does not generate the correct id.
The nodes_test.go also uses machineID.

Reference to https://github.com/poseidon/fleetlock/pull/51

