### PR TITLE
Ignore k8s.io Go modules except client-go

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,16 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 3
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
   pull-request-branch-name:
     separator: "-"
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 1
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 2
+  ignore:
+    - dependency-name: "k8s.io/api"
+    - dependency-name: "k8s.io/apimachinery"


### PR DESCRIPTION
* Prefer to update `k8s.io/client-go`, since that will update related modules. dependabot doesn't group modules together so this is a workaround