### PR TITLE
Change state of lock to unlocked even if holder not found

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -227,7 +227,12 @@ func (s *Server) unlock(w http.ResponseWriter, req *http.Request) {
 		s.log.WithFields(fields).Info("fleetlock: unlocked reboot lease")
 	}
 
-	s.metrics.lockState.With(prometheus.Labels{"group": group}).Set(0)
+	// if the lock holder matches the machine id or if there is no lock holder,
+	// set the lock state for the group to 0, as its available to lock.
+
+	if lock.Holder == id || lock.Holder == "" {
+		s.metrics.lockState.With(prometheus.Labels{"group": group}).Set(0)
+	}
 	// either unlocked or didn't hold
 	fmt.Fprintf(w, "unlocked reboot lease for %s", lock.Holder)
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -223,11 +223,11 @@ func (s *Server) unlock(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		s.metrics.lockState.With(prometheus.Labels{"group": group}).Set(0)
 		s.metrics.lockTransitions.With(prometheus.Labels{"group": group}).Inc()
 		s.log.WithFields(fields).Info("fleetlock: unlocked reboot lease")
 	}
 
+	s.metrics.lockState.With(prometheus.Labels{"group": group}).Set(0)
 	// either unlocked or didn't hold
 	fmt.Fprintf(w, "unlocked reboot lease for %s", lock.Holder)
 }


### PR DESCRIPTION
Currently, the `fleetlock_lock_state` transitions to 0 only if:
* the unlock handler is called and
* a lease with holder matching the id of the machine exists

However, if the lease itself is deleted, a call to the unlock
handler for the same group would succeed, but not change the
metric value for `fleetlock_lock_state` metric. i.e. the metric 
may continue to emit a value of 1. This is not
the expected behavior, since the lock is gone (even if 
the machine that obtained it might still think it has a lock).

This PR changes that behavior so that the metric does change
its value to 0, reflecting the reality that another machine
may obtain a lease on the group. i.e. it is "unlocked".