### PR TITLE
Improve state metrics and unlock reject message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Reset `fleet_lock_state` gauge on first `lock` or `unlock` call ([#71](https://github.com/poseidon/fleetlock/pull/71))
+* Improve reject reply when a client attempts to unlock a lock it doesn't own ([#71](https://github.com/poseidon/fleetlock/pull/71))
+
 ## v0.3.0
 
 * Add support for Kubernetes node draining ([#51](https://github.com/poseidon/fleetlock/pull/51))


### PR DESCRIPTION
* Set `fleet_lock_state` again in lock or unlock calls, so the gauge vector reflects current state sooner, after a fleetlock restart (or manual lease deletion)
* Improve reject reply when a non-owner client attempts to unlock a lease lock it doesn't own