### PR TITLE
Add fleetlock chart

### DIFF
--- a/examples/helm/Chart.yaml
+++ b/examples/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+description: Poseidon fleetlock helm chart. 
+home: https://github.com/poseidon/fleetlock
+name: fleetlock
+sources:
+  - https://github.com/poseidon/fleetlock
+version: 1.0.0

--- a/examples/helm/templates/cluster-role-binding.yaml
+++ b/examples/helm/templates/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fleetlock
+subjects:
+- kind: ServiceAccount
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}

--- a/examples/helm/templates/cluster-role.yaml
+++ b/examples/helm/templates/cluster-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create

--- a/examples/helm/templates/deployment.yaml
+++ b/examples/helm/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: fleetlock
+  template:
+    metadata:
+      labels:
+        name: fleetlock
+    spec:
+      serviceAccountName: fleetlock
+      containers:
+        - name: fleetlock
+          image: quay.io/poseidon/fleetlock:v0.4.0
+          env:
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: 30m
+              memory: 30Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /-/healthy
+

--- a/examples/helm/templates/role-binding.yaml
+++ b/examples/helm/templates/role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fleetlock
+subjects:
+- kind: ServiceAccount
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+

--- a/examples/helm/templates/role.yaml
+++ b/examples/helm/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+

--- a/examples/helm/templates/service-account.yaml
+++ b/examples/helm/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+

--- a/examples/helm/templates/service.yaml
+++ b/examples/helm/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fleetlock
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8080'
+spec:
+  type: ClusterIP
+  clusterIP: {{ .Values.clusterIP}}
+  selector:
+    name: fleetlock
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -1,0 +1,2 @@
+#Cluster IP for the fleetlock service. Zincati talks to this IP.
+clusterIP: 10.96.0.200


### PR DESCRIPTION
This adds a simple fleetlock helm chart. It's mostly k8s examples wrapped in helm.
If this chart is released somewhere this would allow to easily install fleetlock as an extension to a cluster. 

I'm releasing the chart here https://github.com/kaplan-michael/charts