### PR TITLE
Enable deploybot auto-deploy to production

### DIFF
--- a/.github/deploybot.yaml
+++ b/.github/deploybot.yaml
@@ -3,3 +3,4 @@
 # Ordered list of Github Deployment environments
 deployments:
 - name: production
+  on_push: true


### PR DESCRIPTION
* When a commit on main passes tests, deploybot will start a deploy to production