### PR TITLE
Add GitHub Workflow for multi-arch container image build

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -1,0 +1,82 @@
+name: multiarch
+on:
+  workflow_call:
+    secrets:
+      QUAY_TOKEN:
+        description: 'Quay Registry push token'
+        required: false
+jobs:
+  build-amd64:
+    name: build-amd64
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Checkout repo to GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: QEMU packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build Image
+        run: make image-amd64
+
+      - name: Quay Token
+        if: env.QUAY_TOKEN != null
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          buildah login -u "poseidon+github" -p "$QUAY_TOKEN" quay.io
+
+      - name: Push Image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          make push-amd64
+
+  build-arm64:
+    name: build-arm64
+    runs-on: [self-hosted, linux, ARM64]
+    timeout-minutes: 20
+    steps:
+      # Checkout repo to GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Image
+        run: make image-arm64
+
+      - name: Quay Token
+        if: env.QUAY_TOKEN != null
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          buildah login -u "poseidon+github" -p "$QUAY_TOKEN" quay.io
+
+      - name: Push Image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          make push-arm64
+
+  manifest:
+    name: manifest
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - build-amd64
+      - build-arm64
+    steps:
+      # Checkout repo to GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Quay Token
+        if: env.QUAY_TOKEN != null
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          buildah login -u "poseidon+github" -p "$QUAY_TOKEN" quay.io
+
+      - name: Push Multi-Arch
+        run: make manifest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,3 +4,5 @@ on:
 jobs:
   go:
     uses: poseidon/.github/.github/workflows/golang-library.yaml@main
+  multiarch:
+    uses: ./.github/workflows/multiarch.yaml


### PR DESCRIPTION
* Migrate from Drone server to GitHub Actions Workflows for container image builds
* Use self-hosted internal GitHub runners for ARM64, which is neccessary for speed but means we can't run untrusted code. For security, only trigger workflows on push events so that only those with write have permission to run code on the internal runners (PRs will not run builds)
* Shift from internal Drone to public visible GitHub Actions which means logs will be visible and we need to be careful not to leak tokens