### PR TITLE
Add missing Makefile targets for push and manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,17 @@ image-%:
 	--arch $* --override-arch $* \
 	--format=docker .
 
+push-%:
+	buildah tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
+	buildah push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
+
+manifest:
+	buildah manifest create $(IMAGE_REPO):$(VERSION)
+	buildah manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
+	buildah manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
+	buildah manifest inspect $(IMAGE_REPO):$(VERSION)
+	buildah manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)
+
 lock:
 	curl -H "fleet-lock-protocol: true" -d @examples/body.json http://127.0.0.1:8080/v1/pre-reboot
 


### PR DESCRIPTION
* Move container image push and manifest Makefile targets out of the internal Drone setup and into the project's Makefile