### PR TITLE
Checkout git repo with tags and history in GitHub Workflow

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -14,6 +14,8 @@ jobs:
       # Checkout repo to GitHub Actions runner
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build Image
         run: make image-amd64
@@ -38,6 +40,8 @@ jobs:
       # Checkout repo to GitHub Actions runner
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build Image
         run: make image-arm64
@@ -65,6 +69,8 @@ jobs:
       # Checkout repo to GitHub Actions runner
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Quay Token
         if: env.QUAY_TOKEN != null


### PR DESCRIPTION
* By default, the actions/checkout Action fetches only a single commit
* Disable this behavior to fetch all tags which is important for git describe (used in Makefile) to be able to create a version tag