### PR TITLE
query prometheus before setting a lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,24 @@ Configure the server via flags.
 
 Or via environment variables.
 
-| variable   | description            | default   |
-|------------|------------------------|-----------|
-| NAMESPACE  | Kubernetes Namespace   | "default" |
-| KUBECONFIG | Development Kubeconfig | NA        |
+| variable          | description             | default   |
+|-------------------|-------------------------|-----------|
+| NAMESPACE         | Kubernetes Namespace    | "default" |
+| KUBECONFIG        | Development Kubeconfig  | NA        |
+| PROMETHEUS_URL    | Prometheus URL          | NA        |
+| PROMETHEUS_QUERY  | Prometheus Query        | ALERTS    |
+| PROMETHEUS_FILTER | Filter for Prom. Alerts | NA        |
+
+### Prometheus
+
+If the environment variable `PROMETHEUS_URL` is set, fleetlock will query Prometheus for active alerts.
+No reboot lease will can be requested, if there are any active alerts.
+By Default it will fetch all alerts. It is possible to set the environment variable `PROMETHEUS_QUERY` to limit the fetched alerts.
+
+Example Query: `ALERTS{severity="critical",alertstate="firing"}`
+
+With `PROMETHEUS_FILTER` it is possible to filter the fetched alerts. 
+The filter is a regex and if the alert-name is matched, the alert will be exluded.
 
 ### Typhoon
 

--- a/internal/promtheus.go
+++ b/internal/promtheus.go
@@ -1,0 +1,70 @@
+package fleetlock
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"time"
+
+	papi "github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// PromClient is a wrapper around the Prometheus Client interface and implements the api
+// This way, the PromClient can be instantiated with the configuration the Client needs, and
+// the ability to use the methods the api has, like Query and so on.
+type PromClient struct {
+	papi   papi.Client
+	api    v1.API
+	Query  string
+	Filter regexp.Regexp
+}
+
+// NewPromClient creates a new client to the Prometheus API.
+// It returns an error on any problem.
+func NewPromClient(conf papi.Config) (*PromClient, error) {
+	promClient, err := papi.NewClient(conf)
+	if err != nil {
+		return nil, err
+	}
+	client := PromClient{papi: promClient, api: v1.NewAPI(promClient)}
+	return &client, nil
+}
+
+// ActiveAlerts is a method of type PromClient, it returns a list of names of active alerts
+// (e.g. pending or firing), filtered by the supplied regexp.
+// filter by regexp means when the regex finds the alert-name; the alert is exluded from the
+// block-list and will NOT block rebooting.
+func (p *PromClient) ActiveAlerts() ([]string, error) {
+
+	// get all alerts from prometheus
+	value, _, err := p.api.Query(context.Background(), p.Query, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	if value.Type() == model.ValVector {
+		if vector, ok := value.(model.Vector); ok {
+			activeAlertSet := make(map[string]bool)
+			for _, sample := range vector {
+				if alertName, isAlert := sample.Metric[model.AlertNameLabel]; isAlert && sample.Value != 0 {
+					if p.Filter.String() == "" || !p.Filter.MatchString(string(alertName)) {
+						activeAlertSet[string(alertName)] = true
+					}
+				}
+			}
+
+			var activeAlerts []string
+			for activeAlert := range activeAlertSet {
+				activeAlerts = append(activeAlerts, activeAlert)
+			}
+			sort.Strings(activeAlerts)
+
+			return activeAlerts, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unexpected value type from promtheus: %v", value)
+}


### PR DESCRIPTION
Hi

This PR adds the feature to fleetlock, to query Prometheus for active alerts. If there are active alerts fleetlock will deny a request for a lock.

We have been using this patch for several months and it helped so far to make the upgrade process more stable.

The code is based on https://github.com/kubereboot/kured/blob/main/pkg/alerts/prometheus.go, any problems/bugs are mine.