### PR TITLE
Remove auto-deploys to Poseidon internal infra

### DIFF
--- a/.github/deploybot.yaml
+++ b/.github/deploybot.yaml
@@ -1,6 +1,0 @@
-# Config for deploybot.app
-# Docs https://docs.deploybot.app/config/
-# Ordered list of Github Deployment environments
-deployments:
-- name: production
-  on_push: true


### PR DESCRIPTION
* We now use GitHub Actions instead of a private Drone which is great for OSS build transparency, but one drawback to that change is that we no longer auto-deploy matchbox to internal Poseidon Labs infra
* We don't want public workflows for deploys to our private infra