### PR TITLE
Use GitHub-managed runners for ARM64 since they're free

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -34,7 +34,7 @@ jobs:
 
   build-arm64:
     name: build-arm64
-    runs-on: [self-hosted, linux, ARM64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       # Checkout repo to GitHub Actions runner


### PR DESCRIPTION
* No need to use the self-hosted runners now that GitHub provides open-source projects with free ARM64 GitHub runners
* https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/